### PR TITLE
Update to use aws-publish file stream

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Pavan Kumar Sunkara
+Copyright (c) 2015 Lee Pender
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,20 +1,41 @@
-# gulp-cloudfront-invalidate
-A gulp plugin that allows you to invalidate paths in AWS cloudfront
+# gulp-cloudfront-invalidate-aws-publish
+A gulp plugin that allows you to invalidate paths in AWS cloudfront.
+
+This version checks the files that were updated, created, or deleted by
+[gulp-awspublish](https://github.com/pgherveou/gulp-awspublish/), and only
+invalidates those.
+
+This will work with any similar plugin that use the same `file.s3` API internally.
+
+Tested with `gulp-aws-publish` v3.0.1.
+
+See [gulp-awspublish](https://github.com/pgherveou/gulp-awspublish/) for more
+implementation details.
 
 ## Installation
 ```
-npm install gulp-cloudfront-invalidate
+npm install gulp-cloudfront-invalidate-aws-publish
 ```
 
 ## Usage
 
 ```js
 var gulp = require('gulp')
+  , awspublish = require('gulp-aws-publish')
   , cloudfront = require('gulp-cloudfront-invalidate');
 
-var settings = {
+var awsSettings = {
+  region: "...",
+  params: {
+    bucket: "E123123"
+  }
+}
+
+var cfSettings = {
+  // required
   distribution: 'E2A654H2YRPD0W', // Cloudfront distribution ID
-  paths: ['/index.html']          // Paths to invalidate
+
+  // optional
   accessKeyId: '...',             // AWS Access Key ID
   secretAccessKey: '...',         // AWS Secret Access Key
   sessionToken: '...',            // Optional AWS Session Token
@@ -23,25 +44,18 @@ var settings = {
 
 gulp.task('invalidate', function () {
   return gulp.src('*')
-    .pipe(cloudfront(settings));
+    .pipe(awspublish(awsSettings));
+    .pipe(cloudfront(cfSettings));
 });
 ```
 
-
-If you like this project, please watch this and follow me.
-
-## Contributors
-Here is a list of [Contributors](http://github.com/pksunkara/gulp-cloudfront-invalidate/contributors)
-
-__I accept pull requests and guarantee a reply back within a day__
-
-## License
-MIT/X11
-
-## Bug Reports
-Report [here](http://github.com/pksunkara/gulp-cloudfront-invalidate/issues). __Guaranteed reply within a day__.
-
 ## Contact
-Pavan Kumar Sunkara (pavan.sss1991@gmail.com)
+Lee Pender <Lpender@gmail.com>
 
-Follow me on [github](https://github.com/users/follow?target=pksunkara), [twitter](http://twitter.com/pksunkara)
+## Credit
+
+Thanks to:
+
+https://github.com/lpender/gulp-cloudfront-invalidate
+https://github.com/pgherveou/gulp-awspublish
+https://github.com/sindresorhus/gulp-debug/

--- a/package.json
+++ b/package.json
@@ -1,16 +1,17 @@
 {
-  "name": "gulp-cloudfront-invalidate",
-  "version": "0.1.1",
-  "author": "Pavan Kumar Sunkara <pavan.sss1991@gmail.com> (http://pksunkara.github.com)",
-  "description": "A gulp plugin that allows you to invalidate paths in AWS cloudfront",
-  "homepage": "https://github.com/pksunkara/gulp-cloudfront-invalidate",
+  "name": "gulp-cloudfront-invalidate-aws-publish",
+  "version": "0.0.1",
+  "author": "Lee Pender <lpender@gmail.com> (http://lpender.github.com)",
+  "description": "Invalidates paths published with gulp-awspublish",
+  "homepage": "https://github.com/lpender/gulp-cloudfront-invalidate-aws-publish",
   "main": "index.js",
-  "repository": "pksunkara/gulp-cloudfront-invalidate",
+  "repository": "lpender/gulp-cloudfront-invalidate-aws-publish",
   "keywords": [
     "gulp",
     "cloudfront",
     "invalidate",
     "aws",
+    "aws-publish",
     "invalidation"
   ],
   "dependencies": {
@@ -19,12 +20,11 @@
     "through2": "2.0.x"
   },
   "bugs": {
-    "url": "https://github.com/pksunkara/gulp-cloudfront-invalidate/issues"
+    "url": "https://github.com/lpender/gulp-cloudfront-invalidate-aws-publish/issues"
   },
   "licenses": [
     {
-      "type": "MIT",
-      "url": "https://raw.githubusercontent.com/pksunkara/octonode/master/LICENSE"
+      "type": "MIT"
     }
   ]
 }


### PR DESCRIPTION
- Breaks it into two tasks 
  1. _transform: sort which files to invalidate.
  2. _flush: create invalidation.
