### PR TITLE
Fix for 'Unknown state: skip' message

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ module.exports = function (options) {
         files.push(file.s3.path);
         break;
       case 'cache':
+      case 'skip':
         break;
       default:
         util.log("Unknown state: " + file.s3.state);


### PR DESCRIPTION
When `gulp-awspublish` "skips" a file, `gulp-cloudfront-invalidate-aws-publish` logs `Unknown state: skip`. This PR suppresses that message.
