### PR TITLE
Update aws-sdk dependency to match gulp-awspublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "invalidation"
   ],
   "dependencies": {
-    "aws-sdk": "2.1.x",
+    "aws-sdk": "^2.1.16",
     "gulp-util": "3.0.x",
     "through2": "2.0.x"
   },


### PR DESCRIPTION
The current `aws-sdk` dependency version is not exactly the same as the `aws-sdk` used for `aws-publish`. This means that when installing `gulp-cloudfront-invalidate-aws-publish` and `gulp-awspublish` there are two different versions of the `aws-sdk` in the node_modules folder.

Making the dependency specifications the same reduces the size of `node_modules` by at least 5 MB.
