### PR TITLE
Allow the usage of AWS Credentials objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,11 +8,18 @@ module.exports = function (options) {
 
   var cloudfront = new aws.CloudFront();
 
-  cloudfront.config.update({
-    accessKeyId: options.accessKeyId || process.env.AWS_ACCESS_KEY_ID,
-    secretAccessKey: options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY,
-    sessionToken: options.sessionToken || process.env.AWS_SESSION_TOKEN
-  });
+  if ('credentials' in options) {
+    cloudfront.config.update({
+      credentials: options.credentials
+    });
+  }
+  else {
+    cloudfront.config.update({
+      accessKeyId: options.accessKeyId || process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY,
+      sessionToken: options.sessionToken || process.env.AWS_SESSION_TOKEN
+    });
+  }
 
   var files = [];
 


### PR DESCRIPTION
Since gulp-awspublish [passes through Credentials configuration objects](https://github.com/pgherveou/gulp-awspublish/#credentials), I thought it would be nice if this plugin did that as well. This way, instead of loading the credentials manually or putting them in environment variables, they can be loaded [any way that the AWS SDK supports](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Credentials.html).

e.g.:

``` js
var awsCredentials = new AWS.SharedIniFileCredentials({profile: 'myprofile'});
var publisher = awspublish.create({
    region: 'us-east-1',
    params: {
        Bucket: 'my_bucket'
    },
    credentials: awsCredentials
});
var cfSettings = {
    credentials: awsCredentials,
    distribution: 'my_cf_dist'
};
```

thanks for this plugin!
