### PR TITLE
Fix doc and option checking in root path invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ var cfSettings = {
   secretAccessKey: '...',         // Optional AWS Secret Access Key
   sessionToken: '...',            // Optional AWS Session Token
   wait: true,                     // Whether to wait until invalidation is completed (default: false)
-  indexRootPaths: true            // Invalidate index.html root paths (`foo/index.html` and `foo/`) (default: false)
+  indexRootPath: true             // Invalidate index.html root paths (`foo/index.html` and `foo/`) (default: false)
 }
 
 gulp.task('invalidate', function () {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var util = require('gulp-util')
 
 module.exports = function (options) {
   options.wait = !!options.wait;
-  options.indexRoot = !!options.indexRoot;
+  options.indexRootPath = !!options.indexRootPath;
 
   var cloudfront = new aws.CloudFront();
 


### PR DESCRIPTION
I got some issues when using root path invalidation because the README has a typo in the example.
I also fixed the checking that was using the wrong parameter name.
