### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ var cfSettings = {
   secretAccessKey: '...',         // Optional AWS Secret Access Key
   sessionToken: '...',            // Optional AWS Session Token
   wait: true,                     // Whether to wait until invalidation is completed (default: false)
-  indexRootPaths: true            // Invalidate index.html root paths (`foo/index.html` and `foo/`) (default: false)
+  indexRootPath: true             // Invalidate index.html root paths (`foo/index.html` and `foo/`) (default: false)
 }
 
 gulp.task('invalidate', function () {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var util = require('gulp-util')
 
 module.exports = function (options) {
   options.wait = !!options.wait;
-  options.indexRoot = !!options.indexRoot;
+  options.indexRootPath = !!options.indexRootPath;
 
   var cloudfront = new aws.CloudFront();
 


### PR DESCRIPTION
This really confused me at first but the documentation is wrong and the code used 2 different options names. This fixes it all.
