### PR TITLE
Adding support to option `originPath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ var cfSettings = {
   secretAccessKey: '...',         // Optional AWS Secret Access Key
   sessionToken: '...',            // Optional AWS Session Token
   wait: true,                     // Whether to wait until invalidation is completed (default: false)
+  originPath: '/app',             // Configure OriginPath to be removed of file path to invalidation
   indexRootPath: true             // Invalidate index.html root paths (`foo/index.html` and `foo/`) (default: false)
 }
 

--- a/index.js
+++ b/index.js
@@ -58,9 +58,16 @@ module.exports = function (options) {
       case 'update':
       case 'create':
       case 'delete':
-        files.push(file.s3.path);
-        if (options.indexRootPath && /index\.html$/.test(file.s3.path)) {
-          files.push(file.s3.path.replace(/index\.html$/, ''))
+        let path = file.s3.path;
+
+        if (options.originPath) {
+          const originRegex = new RegExp(options.originPath.replace(/^\//, '') + '\/?');
+          path = path.replace(originRegex, '');
+        }
+
+        files.push(path);
+        if (options.indexRootPath && /index\.html$/.test(path)) {
+          files.push(path.replace(/index\.html$/, ''));
         }
         break;
       case 'cache':


### PR DESCRIPTION
when the "Origin Path" is configured, the invalidation should not contain this path, since the root is from the "Origin Path"


Config:

![image](https://user-images.githubusercontent.com/2034678/29387741-df2d5e8a-82b7-11e7-9162-6d0c843856d8.png)


before (wrong):
![image](https://user-images.githubusercontent.com/2034678/29387769-0ac7da52-82b8-11e7-9296-8e4c595b2574.png)

after (ok):
![image](https://user-images.githubusercontent.com/2034678/29387751-f9a15956-82b7-11e7-945f-c9ddbe6cb1e0.png)
