### PR TITLE
Use individual modules instead of gulp-util (Close #17)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var util = require('gulp-util')
+var PluginError = require('plugin-error')
+  , log = require('fancy-log')
   , through = require('through2')
   , aws = require('aws-sdk');
 
@@ -25,7 +26,7 @@ module.exports = function (options) {
 
   var complain = function (err, msg, callback) {
     callback(false);
-    throw new util.PluginError('gulp-cloudfront-invalidate', msg + ': ' + err);
+    throw new PluginError('gulp-cloudfront-invalidate', msg + ': ' + err);
   };
 
   var check = function (id, callback) {
@@ -74,7 +75,7 @@ module.exports = function (options) {
       case 'skip':
         break;
       default:
-        util.log('Unknown state: ' + file.s3.state);
+        log('Unknown state: ' + file.s3.state);
         break;
     }
 
@@ -100,7 +101,7 @@ module.exports = function (options) {
     }, function (err, res) {
       if (err) return complain(err, 'Could not invalidate cloudfront', callback);
 
-      util.log('Cloudfront invalidation created: ' + res.Invalidation.Id);
+      log('Cloudfront invalidation created: ' + res.Invalidation.Id);
 
       if (!options.wait) {
         return callback();

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   ],
   "dependencies": {
     "aws-sdk": "^2.1.16",
-    "gulp-util": "3.0.x",
+    "fancy-log": "1.3.x",
+    "plugin-error": "1.0.x",
     "through2": "2.0.x"
   },
   "bugs": {


### PR DESCRIPTION
See https://github.com/lpender/gulp-cloudfront-invalidate-aws-publish/issues/17 for more details about the migration.