### PR TITLE
Minor authentication issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,13 +14,6 @@ module.exports = function (options) {
       credentials: options.credentials
     });
   }
-  else {
-    cloudfront.config.update({
-      accessKeyId: options.accessKeyId || process.env.AWS_ACCESS_KEY_ID,
-      secretAccessKey: options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY,
-      sessionToken: options.sessionToken || process.env.AWS_SESSION_TOKEN
-    });
-  }
 
   var files = [];
 


### PR DESCRIPTION
Removed looking for AWS credentials from environment variables if they are not explicitly passed in. the AWS SDK for Node does a lot of magic of managing these credentials. When running this code in an ec2 instance or if we are just relying on default named credentials, this section causes the plugin to fail to authenticate.