### PR TITLE
Invalidate index.html root paths (`foo/index.html` and `foo/` and `foo`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ var cfSettings = {
   sessionToken: '...',            // Optional AWS Session Token
   wait: true,                     // Whether to wait until invalidation is completed (default: false)
   originPath: '/app',             // Configure OriginPath to be removed of file path to invalidation
-  indexRootPath: true             // Invalidate index.html root paths (`foo/index.html` and `foo/`) (default: false)
+  indexRootPath: true             // Invalidate index.html root paths (`foo/index.html` and `foo/` and `foo`) (default: false)
 }
 
 gulp.task('invalidate', function () {

--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ module.exports = function (options) {
         files.push(path);
         if (options.indexRootPath && /index\.html$/.test(path)) {
           files.push(path.replace(/index\.html$/, ''));
+          files.push(path.replace(/\/index\.html$/, ''));
         }
         break;
       case 'cache':


### PR DESCRIPTION
I use Lambda Edge to make it accessible without `/index.html` or `/`. So, I would like to invalidate also "no slash" at the time of deployment. I think this purpose like #10.