### PR TITLE
Add support for customizing which index paths are invalidated

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ var cfSettings = {
   sessionToken: '...',            // Optional AWS Session Token
   wait: true,                     // Whether to wait until invalidation is completed (default: false)
   originPath: '/app',             // Configure OriginPath to be removed of file path to invalidation
-  indexRootPath: true             // Invalidate index.html root paths (`foo/index.html` and `foo/`) (default: false)
+  indexFullPath: false            // Invalidate index.html paths (`/foo/index.html`) (default: true)
+  indexTrailingSlashPath: true    // Invalidate index.html trailing slash paths (`/foo/`) (default: false)
+  indexNoTrailingSlashPath: true  // Invalidate index.html no trailing slash paths (`/foo`) (default: false)
 }
 
 gulp.task('invalidate', function () {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ var PluginError = require('plugin-error')
 module.exports = function (options) {
   options.wait = !!options.wait;
   options.indexRootPath = !!options.indexRootPath;
+  options.indexTrailingSlashPath = !!options.indexTrailingSlashPath
+  options.indexNoTrailingSlashPath = !!options.indexNoTrailingSlashPath
 
   var cloudfront = new aws.CloudFront();
 
@@ -66,10 +68,20 @@ module.exports = function (options) {
           path = path.replace(originRegex, '');
         }
 
-        files.push(path);
-        if (options.indexRootPath && /index\.html$/.test(path)) {
-          files.push(path.replace(/index\.html$/, ''));
+        if (/\/index\.html$/.test(path)) {
+          if (options.indexFullPath !== false) {
+            files.push(path);
+          }
+          if (options.indexTrailingSlashPath || options.indexRootPath) {
+            files.push(path.replace(/\/index\.html$/, '/'));
+          }
+          if (options.indexNoTrailingSlashPath) {
+            files.push(path.replace(/\/index\.html$/, ''));
+          }
+        } else {
+          files.push(path);
         }
+
         break;
       case 'cache':
       case 'skip':


### PR DESCRIPTION
Purpose: Optimize invalidation costs by only invalidating the specific paths needed.

Configuration options:
```js
indexFullPath: false            // Invalidate index.html paths (`/foo/index.html`) (default: true)
indexTrailingSlashPath: true    // Invalidate index.html trailing slash paths (`/foo/`) (default: false)
indexNoTrailingSlashPath: true  // Invalidate index.html no trailing slash paths (`/foo`) (default: false)
```
Backwards compatible: Same default behavior. `indexRootPath` removed from readme but still functional.